### PR TITLE
0194

### DIFF
--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -197,14 +197,16 @@ def discover(superclass):
         assert os.path.isdir(path), "%s is not a directory" % path
 
         for fname in os.listdir(path):
-            abspath = os.path.join(path, fname)
-
-            if not os.path.isfile(abspath):
+            # Ignore files which start with underscore
+            if fname.startswith("_"):
                 continue
 
             mod_name, mod_ext = os.path.splitext(fname)
-
             if not mod_ext == ".py":
+                continue
+
+            abspath = os.path.join(path, fname)
+            if not os.path.isfile(abspath):
                 continue
 
             module = types.ModuleType(mod_name)

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-# from ...vendor import qtawesome
 from ...vendor.Qt import QtWidgets, QtCore
 from ... import api, io
 from .. import lib
@@ -170,17 +169,22 @@ class Window(QtWidgets.QDialog):
         assets = [asset for asset in assets_db if asset_name in asset["name"]]
 
         if assets:
+            # Get plugin and family
+            plugin = item.data(PluginRole)
+            family = plugin.family.rsplit(".", 1)[-1]
+
             # Get all subsets of the current asset
             asset_ids = [asset["_id"] for asset in assets]
             subsets = io.find(filter={"type": "subset",
+                                      "name": {"$regex": "{}*".format(family),
+                                               "$options": "i"},
                                       "parent": {"$in": asset_ids}}) or []
 
-            subsets = [subset["name"] for subset in subsets]
+            # Get all subsets' their description name, "Default", "High", "Low"
+            subsets = [subset["name"].split(family)[-1] for subset in subsets]
             self._build_menu(subsets)
 
             # Update the result
-            plugin = item.data(PluginRole)
-            family = plugin.family.rsplit(".", 1)[-1]
             if subset_name:
                 subset_name = subset_name[0].upper() + subset_name[1:]
             result.setText("{}{}".format(family, subset_name))

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -155,11 +155,11 @@ class Window(QtWidgets.QDialog):
 
     def _on_data_changed(self):
 
+        listing = self.data["Listing"]
         asset_name = self.data["Asset"]
-        button = self.data["Create Button"]
         subset = self.data["Subset"]
         result = self.data["Result"]
-        listing = self.data["Listing"]
+        button = self.data["Create Button"]
 
         item = listing.currentItem()
         subset_name = subset.text()
@@ -180,13 +180,13 @@ class Window(QtWidgets.QDialog):
 
             # Update the result
             plugin = item.data(PluginRole)
+            family = plugin.family.rsplit(".", 1)[-1]
             if subset_name:
                 subset_name = subset_name[0].upper() + subset_name[1:]
-
-            result.setText("{}{}".format(plugin.name, subset_name))
+            result.setText("{}{}".format(family, subset_name))
 
             item.setData(ExistsRole, True)
-            self.echo("Ready, existing subset ..")
+            self.echo("Ready ..")
         else:
             self._build_menu([])
             item.setData(ExistsRole, False)

--- a/avalon/tools/creator/app.py
+++ b/avalon/tools/creator/app.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+# from ...vendor import qtawesome
 from ...vendor.Qt import QtWidgets, QtCore
 from ... import api, io
 from .. import lib
@@ -21,6 +22,9 @@ class Window(QtWidgets.QDialog):
         self.setWindowTitle("Instance Creator")
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
 
+        # Store the widgets for lookup in here
+        self.data = dict()
+
         body = QtWidgets.QWidget()
         lists = QtWidgets.QWidget()
         footer = QtWidgets.QWidget()
@@ -30,6 +34,23 @@ class Window(QtWidgets.QDialog):
         listing = QtWidgets.QListWidget()
         asset = QtWidgets.QLineEdit()
         name = QtWidgets.QLineEdit()
+        result = QtWidgets.QLineEdit()
+        result.setReadOnly(True)
+
+        # region Menu for default subset names
+
+        subset_button = QtWidgets.QPushButton()
+        subset_button.setFixedWidth(18)
+        subset_button.setFixedHeight(20)
+        subset_menu = QtWidgets.QMenu(subset_button)
+        subset_button.setMenu(subset_menu)
+
+        # endregion
+
+        name_layout = QtWidgets.QHBoxLayout()
+        name_layout.addWidget(name)
+        name_layout.addWidget(subset_button)
+        name_layout.setContentsMargins(0, 0, 0, 0)
 
         layout = QtWidgets.QVBoxLayout(container)
         layout.addWidget(QtWidgets.QLabel("Family"))
@@ -37,19 +58,17 @@ class Window(QtWidgets.QDialog):
         layout.addWidget(QtWidgets.QLabel("Asset"))
         layout.addWidget(asset)
         layout.addWidget(QtWidgets.QLabel("Subset"))
-        layout.addWidget(name)
+        layout.addLayout(name_layout)
+        layout.addWidget(result)
         layout.setContentsMargins(0, 0, 0, 0)
 
         options = QtWidgets.QWidget()
 
-        autoclose_chk = QtWidgets.QCheckBox("Auto-close")
-        autoclose_chk.setCheckState(QtCore.Qt.Checked)
         useselection_chk = QtWidgets.QCheckBox("Use selection")
         useselection_chk.setCheckState(QtCore.Qt.Checked)
 
         layout = QtWidgets.QGridLayout(options)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(autoclose_chk, 1, 0)
         layout.addWidget(useselection_chk, 1, 1)
 
         layout = QtWidgets.QHBoxLayout(lists)
@@ -74,76 +93,129 @@ class Window(QtWidgets.QDialog):
         layout.addWidget(body)
         layout.addWidget(footer)
 
-        names = {
-            create_btn: "Create Button",
-            listing: "Listing",
-            useselection_chk: "Use Selection Checkbox",
-            autoclose_chk: "Autoclose Checkbox",
-            name: "Subset",
-            asset: "Asset",
-            error_msg: "Error Message",
+        self.data = {
+            "Create Button": create_btn,
+            "Listing": listing,
+            "Use Selection Checkbox": useselection_chk,
+            "Subset": name,
+            "Subset Menu": subset_menu,
+            "Result": result,
+            "Asset": asset,
+            "Error Message": error_msg,
         }
 
-        for widget, name_ in names.items():
-            widget.setObjectName(name_)
+        for _name, widget in self.data.items():
+            widget.setObjectName(_name)
 
         create_btn.clicked.connect(self.on_create)
         name.returnPressed.connect(self.on_create)
-        asset.textChanged.connect(self.on_data_changed)
         name.textChanged.connect(self.on_data_changed)
+        asset.textChanged.connect(self.on_data_changed)
         listing.currentItemChanged.connect(self.on_selection_changed)
 
         # Defaults
-        self.resize(220, 250)
+        self.resize(220, 300)
         name.setFocus()
         create_btn.setEnabled(False)
 
+    def _build_menu(self, default_names):
+        """Create optional predefines subset names
+
+        Args:
+            default_names(list): all predefined names
+
+        Returns:
+             None
+        """
+
+        menu = self.data["Subset Menu"]
+        button = menu.parent()
+
+        # Get and destroy the action group
+        group = button.findChild(QtWidgets.QActionGroup)
+        if group:
+            group.deleteLater()
+
+        state = any(default_names)
+        button.setEnabled(state)
+        if state is False:
+            return
+
+        # Build new action group
+        group = QtWidgets.QActionGroup(button)
+        for name in default_names:
+            action = group.addAction(name)
+            menu.addAction(action)
+
+        group.triggered.connect(self._on_action_clicked)
+
+    def _on_action_clicked(self, action):
+        name = self.data["Subset"]
+        name.setText(action.text())
+
+    def _on_data_changed(self):
+
+        asset_name = self.data["Asset"]
+        button = self.data["Create Button"]
+        subset = self.data["Subset"]
+        result = self.data["Result"]
+        listing = self.data["Listing"]
+
+        item = listing.currentItem()
+        subset_name = subset.text()
+        asset_name = asset_name.text()
+
+        # Get the assets from the database which match with the name
+        assets_db = io.find(filter={"type": "asset"}, projection={"name": 1})
+        assets = [asset for asset in assets_db if asset_name in asset["name"]]
+
+        if assets:
+            # Get all subsets of the current asset
+            asset_ids = [asset["_id"] for asset in assets]
+            subsets = io.find(filter={"type": "subset",
+                                      "parent": {"$in": asset_ids}}) or []
+
+            subsets = [subset["name"] for subset in subsets]
+            self._build_menu(subsets)
+
+            # Update the result
+            plugin = item.data(PluginRole)
+            if subset_name:
+                subset_name = subset_name[0].upper() + subset_name[1:]
+
+            result.setText("{}{}".format(plugin.name, subset_name))
+
+            item.setData(ExistsRole, True)
+            self.echo("Ready, existing subset ..")
+        else:
+            self._build_menu([])
+            item.setData(ExistsRole, False)
+            self.echo("'%s' not found .." % asset_name)
+
+        button.setEnabled(
+            subset_name.strip() != "" and
+            asset_name.strip() != "" and
+            item.data(QtCore.Qt.ItemIsEnabled) and
+            item.data(ExistsRole)
+        )
+
     def on_data_changed(self, *args):
-        button = self.findChild(QtWidgets.QPushButton, "Create Button")
+        button = self.data["Create Button"]
         button.setEnabled(False)
         lib.schedule(self._on_data_changed, 500, channel="gui")
 
     def on_selection_changed(self, *args):
-        name = self.findChild(QtWidgets.QWidget, "Subset")
-        item = self.findChild(QtWidgets.QWidget, "Listing").currentItem()
+        name = self.data["Subset"]
+        item = self.data["Listing"].currentItem()
 
         plugin = item.data(PluginRole)
-
         if plugin is None:
             return
 
-        label = (
-            plugin.name or
-            plugin.family.lower().rsplit(".", 1)[-1] + "Default"
-        )
-
+        label = "Default"
         name.setText(label)
 
         self.on_data_changed()
-
-    def _on_data_changed(self):
-        button = self.findChild(QtWidgets.QPushButton, "Create Button")
-        asset = self.findChild(QtWidgets.QWidget, "Asset")
-        name = self.findChild(QtWidgets.QWidget, "Subset")
-        item = self.findChild(QtWidgets.QWidget, "Listing").currentItem()
-
-        if asset.text() in (asset["name"]
-                            for asset in io.find(
-                                filter={"type": "asset"},
-                                projection={"name": 1})):
-            item.setData(ExistsRole, True)
-            self.echo("Ready..")
-
-        else:
-            item.setData(ExistsRole, False)
-            self.echo("'%s' not found.." % asset.text())
-
-        button.setEnabled(
-            name.text().strip() != "" and
-            asset.text().strip() != "" and
-            item.data(QtCore.Qt.ItemIsEnabled) and
-            item.data(ExistsRole)
-        )
 
     def keyPressEvent(self, event):
         """Custom keyPressEvent.
@@ -156,8 +228,9 @@ class Window(QtWidgets.QDialog):
         """
 
     def refresh(self):
-        listing = self.findChild(QtWidgets.QWidget, "Listing")
-        asset = self.findChild(QtWidgets.QWidget, "Asset")
+
+        listing = self.data["Listing"]
+        asset = self.data["Asset"]
         asset.setText(os.environ["AVALON_ASSET"])
 
         has_families = False
@@ -184,47 +257,42 @@ class Window(QtWidgets.QDialog):
         listing.setCurrentItem(listing.item(0))
 
     def on_create(self):
-        button = self.findChild(QtWidgets.QPushButton, "Create Button")
 
-        if not button.isEnabled():
-            return
-
-        asset = self.findChild(QtWidgets.QWidget, "Asset")
-        listing = self.findChild(QtWidgets.QWidget, "Listing")
-        autoclose_chk = self.findChild(QtWidgets.QWidget,
-                                       "Autoclose Checkbox")
-        useselection_chk = self.findChild(QtWidgets.QWidget,
-                                          "Use Selection Checkbox")
+        asset = self.data["Asset"]
+        listing = self.data["Listing"]
+        result = self.data["Result"]
 
         item = listing.currentItem()
+        useselection_chk = self.data["Use Selection Checkbox"]
 
         if item is not None:
-            name = self.findChild(QtWidgets.QWidget, "Subset").text()
+            subset_name = result.text()
             asset = asset.text()
             family = item.data(FamilyRole)
+        else:
+            return
 
-            try:
-                host = api.registered_host()
-                host.create(name, asset, family, options={
-                    "useSelection": useselection_chk.checkState()
-                })
+        try:
+            host = api.registered_host()
+            host.create(subset_name,
+                        asset,
+                        family,
+                        options={"useSelection":
+                                 useselection_chk.checkState()}
+                        )
 
-            except NameError as e:
-                self.echo(e)
-                raise
+        except NameError as e:
+            self.echo(e)
+            raise
 
-            except (TypeError, RuntimeError, KeyError, AssertionError) as e:
-                self.echo("Program error: %s" % str(e))
-                raise
-
-        if autoclose_chk.checkState():
-            self.close()
+        except (TypeError, RuntimeError, KeyError, AssertionError) as e:
+            self.echo("Program error: %s" % str(e))
+            raise
 
     def echo(self, message):
-        widget = self.findChild(QtWidgets.QWidget, "Error Message")
+        widget = self.data["Error Message"]
         widget.setText(str(message))
         widget.show()
-        print(message)
 
         lib.schedule(lambda: widget.setText(""), 5000, channel="message")
 


### PR DESCRIPTION
Main updates:

* Takes `plugin.family` instead of `plugin.name`
    * Makes use of `.rsplit(".", 1)` to ensure any namespaces are removed

* Introduces published subset dropdown menu:
    * Active only when subsets for the asset's family are found in the database
    * Gives the user the ability to continue on that subset / variation by selecting one

* Cosmetics changes
    * `self.findChild(type, name)` is replaced with `self.data[name]`