### PR TITLE
Exclude /style directory from tests

### DIFF
--- a/run_maya_tests.py
+++ b/run_maya_tests.py
@@ -47,6 +47,9 @@ if __name__ == "__main__":
         # We can expect any vendors to
         # be well tested beforehand.
         "--exclude-dir=avalon/vendor",
+        
+        # These are vendored and unmodified by Avalon
+        "--exclude-dir=avalon/style",
     ])
 
     nose.main(argv=argv,


### PR DESCRIPTION
Unsure of why I wasn't allowed to make this change directly. Anyway, this *should* do it, but it's hard to know without running it.