### PR TITLE
Add family filter defined from config

### DIFF
--- a/avalon/api.py
+++ b/avalon/api.py
@@ -22,7 +22,7 @@ from .pipeline import (
     discover,
     Session,
 
-    # Deprectated
+    # Deprecated
     Session as session,
 
     on,
@@ -40,6 +40,7 @@ from .pipeline import (
     update_current_task,
     get_representation_path,
     loaders_from_representation,
+    get_data,
 
     register_root,
     register_host,
@@ -89,6 +90,7 @@ __all__ = [
     "update_current_task",
     "get_representation_path",
     "loaders_from_representation",
+    "get_data",
 
     "register_host",
     "register_plugin_path",

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -37,11 +37,11 @@ from .pipeline import (
     switch,
     remove,
 
+    data,
+
     update_current_task,
     get_representation_path,
     loaders_from_representation,
-    get_data,
-    set_data,
 
     register_root,
     register_host,
@@ -88,11 +88,11 @@ __all__ = [
     "switch",
     "remove",
 
+    "data",
+
     "update_current_task",
     "get_representation_path",
     "loaders_from_representation",
-    "get_data",
-    "set_data",
 
     "register_host",
     "register_plugin_path",

--- a/avalon/api.py
+++ b/avalon/api.py
@@ -41,6 +41,7 @@ from .pipeline import (
     get_representation_path,
     loaders_from_representation,
     get_data,
+    set_data,
 
     register_root,
     register_host,
@@ -91,6 +92,7 @@ __all__ = [
     "get_representation_path",
     "loaders_from_representation",
     "get_data",
+    "set_data",
 
     "register_host",
     "register_plugin_path",

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -32,7 +32,7 @@ from .vendor import six
 self = sys.modules[__name__]
 self._is_installed = False
 self._config = None
-self._data = {}
+self.data = {}
 
 log = logging.getLogger(__name__)
 
@@ -612,31 +612,6 @@ def register_config(config):
 
     _validate_signature(config, signatures)
     _registered_config["_"] = config
-
-
-def set_data(key, value):
-    """Set custom data which is accessible through a key word
-
-    Examples:
-        Example for the Loader to override family states
-        set_data("family_states", {"familyA": False, "familyB": False})
-
-    """
-
-    self._data[key] = value
-
-
-def get_data(key):
-    """Retrieve custom data
-
-    Args:
-        key (str): name used to store data under
-
-    Returns:
-        stored data or None
-    """
-
-    return self._data.get(key, None)
 
 
 def _validate_signature(module, signatures):

--- a/avalon/pipeline.py
+++ b/avalon/pipeline.py
@@ -32,6 +32,7 @@ from .vendor import six
 self = sys.modules[__name__]
 self._is_installed = False
 self._config = None
+self._data = {}
 
 log = logging.getLogger(__name__)
 
@@ -611,6 +612,31 @@ def register_config(config):
 
     _validate_signature(config, signatures)
     _registered_config["_"] = config
+
+
+def set_data(key, value):
+    """Set custom data which is accessible through a key word
+
+    Examples:
+        Example for the Loader to override family states
+        set_data("family_states", {"familyA": False, "familyB": False})
+
+    """
+
+    self._data[key] = value
+
+
+def get_data(key):
+    """Retrieve custom data
+
+    Args:
+        key (str): name used to store data under
+
+    Returns:
+        stored data or None
+    """
+
+    return self._data.get(key, None)
 
 
 def _validate_signature(module, signatures):

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -1,5 +1,5 @@
 from ...vendor import qtawesome
-from ... import io, pipeline
+from ... import io, api
 
 FAMILY_ICON_COLOR = "#0091B2"
 FAMILY_CONFIG = {}
@@ -36,7 +36,7 @@ def refresh_family_config():
     families = {family['name']: family for family in families}
 
     # Check if any family state are being overwritten by the configuration
-    family_states = pipeline.get_data("family_states") or {}
+    family_states = api.data.get("familyStates",  {})
 
     # Replace icons with a Qt icon we can use in the user interfaces
     default_icon = qtawesome.icon("fa.folder", color=FAMILY_ICON_COLOR)

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -36,7 +36,8 @@ def refresh_family_config():
     families = {family['name']: family for family in families}
 
     # Check if any family state are being overwritten by the configuration
-    family_states = api.data.get("familyStates",  {})
+    default_state = api.data.get("familiesStateDefault", True)
+    toggled = set(api.data.get("familiesStateToggled", []))
 
     # Replace icons with a Qt icon we can use in the user interfaces
     default_icon = qtawesome.icon("fa.folder", color=FAMILY_ICON_COLOR)
@@ -50,7 +51,8 @@ def refresh_family_config():
             family['icon'] = default_icon
 
         # Update state
-        family["state"] = family_states.get(name, True)
+        state = not default_state if name in toggled else default_state
+        family["state"] = state
 
     # Default configuration
     families["__default__"] = {"icon": default_icon}

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -36,8 +36,7 @@ def refresh_family_config():
     families = {family['name']: family for family in families}
 
     # Check if any family state are being overwritten by the configuration
-    data = pipeline.get_data("family_states") or {}
-    family_states = {family: data.get(family, True) for family in families}
+    family_states = pipeline.get_data("family_states") or {}
 
     # Replace icons with a Qt icon we can use in the user interfaces
     default_icon = qtawesome.icon("fa.folder", color=FAMILY_ICON_COLOR)
@@ -51,7 +50,7 @@ def refresh_family_config():
             family['icon'] = default_icon
 
         # Update state
-        family.update(family_states[name])
+        family["state"] = family_states.get(name, True)
 
     # Default configuration
     families["__default__"] = {"icon": default_icon}

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -1,5 +1,3 @@
-import importlib
-
 from ...vendor import qtawesome
 from ... import io, pipeline
 
@@ -37,8 +35,10 @@ def refresh_family_config():
     families = project['config'].get("families", [])
     families = {family['name']: family for family in families}
 
-    # Get all family states based on the config
-    family_states = get_family_filters(families)
+    # Check if any family state are being overwritten by the configuration
+    data = pipeline.get_data("family_states") or {}
+    family_states = {family: data.get(family, True) for family in families}
+
     # Replace icons with a Qt icon we can use in the user interfaces
     default_icon = qtawesome.icon("fa.folder", color=FAMILY_ICON_COLOR)
     for name, family in families.items():
@@ -60,42 +60,3 @@ def refresh_family_config():
     FAMILY_CONFIG.update(families)
 
     return families
-
-
-def get_family_filters(families):
-    """Set the family states based on host settings
-
-    This function has no effect if the lib module or the function in not present
-    in the registered config.
-
-    Args:
-        families (iterable): collection of family names, example:
-                             ["polly.imagesequence", "polly.camera_abc"]
-
-    Returns:
-        dict: collection of family settings
-    """
-
-    # Find host's lib module in the registered config
-    host = pipeline.registered_host()
-    host_name = host.__name__.rsplit(".", 1)[-1]
-
-    config = pipeline.registered_config()
-    config_name = config.__name__.split(".", 1)[0]
-    config_lib_module = "{}.{}.lib".format(config_name, host_name)
-
-    # Check if host is compatible
-    try:
-        lib = importlib.import_module(config_lib_module)
-    except (ValueError, TypeError, RuntimeError):
-        print("Configuration has no module called {0} or "
-              "{0}.lib".format(host_name))
-        return {}
-
-    if not hasattr(lib, "set_family_filter"):
-        return {}
-
-    new_states = {name: {"state": lib.set_family_filter(name)}
-                  for name in families}
-
-    return new_states

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -26,6 +26,16 @@ def refresh_family_config():
         }
     }
 
+    It is possible to override the default behavior and set specific families
+    checked. For example we only want the families imagesequense and camera
+    to be visible in the Loader.
+
+    # This will turn every item off
+    api.data["familyStateDefault"] = False
+
+    # Only allow the imagesequence and camera
+    api.data["familyStateToggled"] = ["imagesequence", "camera"]
+
     """
     # Update the icons from the project configuration
     project = io.find_one({"type": "project"},

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -27,7 +27,7 @@ def refresh_family_config():
     }
 
     It is possible to override the default behavior and set specific families
-    checked. For example we only want the families imagesequense and camera
+    checked. For example we only want the families imagesequence  and camera
     to be visible in the Loader.
 
     # This will turn every item off

--- a/avalon/tools/cbloader/lib.py
+++ b/avalon/tools/cbloader/lib.py
@@ -1,5 +1,7 @@
+import importlib
+
 from ...vendor import qtawesome
-from ... import io
+from ... import io, pipeline
 
 FAMILY_ICON_COLOR = "#0091B2"
 FAMILY_CONFIG = {}
@@ -30,20 +32,26 @@ def refresh_family_config():
     # Update the icons from the project configuration
     project = io.find_one({"type": "project"},
                           projection={"config.families": True})
-    if not project:
-        raise RuntimeError("Project not found")
+
+    assert project, "Project not found!"
     families = project['config'].get("families", [])
     families = {family['name']: family for family in families}
 
+    # Get all family states based on the config
+    family_states = get_family_filters(families)
     # Replace icons with a Qt icon we can use in the user interfaces
     default_icon = qtawesome.icon("fa.folder", color=FAMILY_ICON_COLOR)
     for name, family in families.items():
+        # Set family icon
         icon = family.get("icon", None)
         if icon:
             family['icon'] = qtawesome.icon("fa.{}".format(icon),
                                             color=FAMILY_ICON_COLOR)
         else:
             family['icon'] = default_icon
+
+        # Update state
+        family.update(family_states[name])
 
     # Default configuration
     families["__default__"] = {"icon": default_icon}
@@ -52,3 +60,42 @@ def refresh_family_config():
     FAMILY_CONFIG.update(families)
 
     return families
+
+
+def get_family_filters(families):
+    """Set the family states based on host settings
+
+    This function has no effect if the lib module or the function in not present
+    in the registered config.
+
+    Args:
+        families (iterable): collection of family names, example:
+                             ["polly.imagesequence", "polly.camera_abc"]
+
+    Returns:
+        dict: collection of family settings
+    """
+
+    # Find host's lib module in the registered config
+    host = pipeline.registered_host()
+    host_name = host.__name__.rsplit(".", 1)[-1]
+
+    config = pipeline.registered_config()
+    config_name = config.__name__.split(".", 1)[0]
+    config_lib_module = "{}.{}.lib".format(config_name, host_name)
+
+    # Check if host is compatible
+    try:
+        lib = importlib.import_module(config_lib_module)
+    except (ValueError, TypeError, RuntimeError):
+        print("Configuration has no module called {0} or "
+              "{0}.lib".format(host_name))
+        return {}
+
+    if not hasattr(lib, "set_family_filter"):
+        return {}
+
+    new_states = {name: {"state": lib.set_family_filter(name)}
+                  for name in families}
+
+    return new_states


### PR DESCRIPTION
Fixes FUS42
When the tool is being initialized the configuration is being checked if it has any preferences for the family widget. Based on the host (Fusion for example) and the `set_family_state` function it will set the correct families on or off.

To ensure backwards compatibility and cross configurations there is a check prior to fetching all states.

Updates to code:
* Added assertion instead of `if not: RuntimeError`
* Added function to fetch family states from config
  * With compatibility check