### PR TITLE
Install config when launching standalone tool

### DIFF
--- a/avalon/tools/cbloader/app.py
+++ b/avalon/tools/cbloader/app.py
@@ -331,30 +331,24 @@ def cli(args):
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-project")
-    parser.add_argument("-config", required=False, type=str)
+    parser.add_argument("project")
 
     args = parser.parse_args(args)
     project = args.project
-    config = args.config
 
     io.install()
 
     # Store settings
     api.Session["AVALON_PROJECT"] = project
 
-    if config:
+    from avalon import pipeline
 
-        from ... import pipeline
-
-        api.Session["AVALON_CONFIG"] = config
-
-        # Find the set config
-        _config = pipeline.find_config()
-        if hasattr(_config, "install"):
-            _config.install()
-        else:
-            print("Config `%s` has no function `install`" %
-                  config.__name__)
+    # Find the set config
+    _config = pipeline.find_config()
+    if hasattr(_config, "install"):
+        _config.install()
+    else:
+        print("Config `%s` has no function `install`" %
+              _config.__name__)
 
     show()


### PR DESCRIPTION
In this PR the CB Loader has been updated to install the configuration which is used.
This is order to support plugins which can be used without a host such as `Copy File` and `Copy File Path`.

Updated the `cli` function to try to install the configuration, updated the version as well.