### PR TITLE
[Houdini] Improvements

### DIFF
--- a/avalon/houdini/lib.py
+++ b/avalon/houdini/lib.py
@@ -33,21 +33,21 @@ def imprint(node, data):
 
         if isinstance(value, float):
             parm = hou.FloatParmTemplate(name=key,
-                                         label=key.title(),
+                                         label=key,
                                          num_components=1,
                                          default_value=(value,))
         elif isinstance(value, bool):
             parm = hou.ToggleParmTemplate(name=key,
-                                          label=key.title(),
+                                          label=key,
                                           default_value=value)
         elif isinstance(value, int):
             parm = hou.IntParmTemplate(name=key,
-                                       label=key.title(),
+                                       label=key,
                                        num_components=1,
                                        default_value=(value,))
         elif isinstance(value, six.string_types):
             parm = hou.StringParmTemplate(name=key,
-                                          label=key.title(),
+                                          label=key,
                                           num_components=1,
                                           default_value=(value,))
         else:

--- a/avalon/houdini/lib.py
+++ b/avalon/houdini/lib.py
@@ -13,6 +13,8 @@ def imprint(node, data):
     template. Houdini uses a template per type, see the docs for more
     information.
 
+    http://www.sidefx.com/docs/houdini/hom/hou/ParmTemplate.html
+
     Args:
         node(hou.Node): node object from Houdini
         data(dict): collection of attributes and their value
@@ -34,15 +36,15 @@ def imprint(node, data):
                                          label=key.title(),
                                          num_components=1,
                                          default_value=(value,))
+        elif isinstance(value, bool):
+            parm = hou.ToggleParmTemplate(name=key,
+                                          label=key.title(),
+                                          default_value=value)
         elif isinstance(value, int):
             parm = hou.IntParmTemplate(name=key,
                                        label=key.title(),
                                        num_components=1,
                                        default_value=(value,))
-        elif isinstance(value, bool):
-            parm = hou.ToggleParmTemplate(name=key,
-                                          label=key.title(),
-                                          default_value=(value,))
         elif isinstance(value, six.string_types):
             parm = hou.StringParmTemplate(name=key,
                                           label=key.title(),

--- a/avalon/houdini/lib.py
+++ b/avalon/houdini/lib.py
@@ -84,7 +84,7 @@ def lsattrs(attrs):
     """
 
     matches = set()
-    nodes = hou.node("/obj").children()
+    nodes = list(hou.node("/obj").allNodes())  # returns generator object
     for node in nodes:
         for attr in attrs:
             if not node.parm(attr):

--- a/avalon/houdini/pipeline.py
+++ b/avalon/houdini/pipeline.py
@@ -223,7 +223,7 @@ def containerise(name,
     lib.imprint(container, data)
 
     # "Parent" the container under the container network
-    hou.copyNodesTo([container], container_network)
+    hou.moveNodesTo([container], container_network)
 
     # Get the container and set good position
     container_network.node(name).moveToGoodPosition()


### PR DESCRIPTION
* Created AVALON_CONTAINERS
* `lib.imprint` no longer creates a "title" which can make attributes unreadable
* Move nodes instead of copy to `AVALON_CONTAINERS/ROOT`
* Updated `lsattr`: get all nodes under `/obj`