### PR TITLE
Wrapping Creator.process in an undo chunk

### DIFF
--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -105,11 +105,19 @@ def export_alembic(nodes,
 
     Arguments:
         nodes (list): Long names of nodes to cache
+
         file (str): Absolute path to output destination
+
         frame_range (tuple, optional): Start- and end-frame of cache,
             default to current animation range.
-        uv_write (bool, optional): Whether or not to include UVs,
+
+        write_uv (bool, optional): Whether or not to include UVs,
             default to True
+
+        write_visibility (bool, optional): Turn on to store the visibility
+        state of objects in the Alembic file. Otherwise, all objects are
+        considered visible, default to True
+
         attribute_prefix (str, optional): Include all user-defined
             attributes with this prefix.
 

--- a/avalon/maya/lib.py
+++ b/avalon/maya/lib.py
@@ -154,6 +154,17 @@ def export_alembic(nodes,
     return mel.eval(mel_cmd)
 
 
+@contextlib.contextmanager
+def undo_chunk():
+    """Open a undo chunk during context."""
+
+    try:
+        cmds.undoInfo(openChunk=True)
+        yield
+    finally:
+        cmds.undoInfo(closeChunk=True)
+
+
 def imprint(node, data):
     """Write `data` to `node` as userDefined attributes
 

--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -454,11 +454,12 @@ class Creator(api.Creator):
     def process(self):
         nodes = list()
 
-        if (self.options or {}).get("useSelection"):
-            nodes = cmds.ls(selection=True)
+        with lib.undo_chunk():
+            if (self.options or {}).get("useSelection"):
+                nodes = cmds.ls(selection=True)
 
-        instance = cmds.sets(nodes, name=self.name)
-        lib.imprint(instance, self.data)
+            instance = cmds.sets(nodes, name=self.name)
+            lib.imprint(instance, self.data)
 
         return instance
 


### PR DESCRIPTION
In order to make the creation of instances undoable I have created a contextmanager function in the maya.pipeline module of the core.

Adjustments:
* Added `undo_chunk` contextmanager function
* Updated `Creator.process` method to contain the `undo_chunk`
* Updated doc strings