### PR TITLE
Workfiles

### DIFF
--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -251,6 +251,7 @@ class Window(QtWidgets.QDialog):
 
         self.duplicate_button.pressed.connect(self.on_duplicate_pressed)
         self.open_button.pressed.connect(self.on_open_pressed)
+        self.list.doubleClicked.connect(self.on_open_pressed)
         self.browse_button.pressed.connect(self.on_browse_pressed)
         self.save_as_button.pressed.connect(self.on_save_as_pressed)
 

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -306,6 +306,10 @@ class Window(QtWidgets.QDialog):
         if self.list.count():
             item = self.list.item(modified.index(max(modified)))
             item.setSelected(True)
+
+            # Scroll list so item is visible
+            QtCore.QTimer.singleShot(100, lambda: self.list.scrollToItem(item))
+
             self.duplicate_button.setEnabled(True)
         else:
             self.duplicate_button.setEnabled(False)

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -252,6 +252,21 @@ class Window(QtWidgets.QDialog):
         self.layout = QtWidgets.QVBoxLayout()
         self.setLayout(self.layout)
 
+        # Display current context
+        # todo: context should update on update task
+        label = u"<b>Asset</b> {0} \u25B6 <b>Task</b> {1}".format(
+            api.Session["AVALON_ASSET"],
+            api.Session["AVALON_TASK"]
+        )
+        self.context_label = QtWidgets.QLabel(label)
+        self.context_label.setStyleSheet("QLabel{ font-size: 12pt; }")
+        self.layout.addWidget(self.context_label)
+
+        separator = QtWidgets.QFrame()
+        separator.setFrameShape(QtWidgets.QFrame.HLine)
+        separator.setFrameShadow(QtWidgets.QFrame.Plain)
+        self.layout.addWidget(separator)
+
         self.list = QtWidgets.QListWidget()
         self.layout.addWidget(self.list)
 

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -257,6 +257,7 @@ class Window(QtWidgets.QDialog):
         self.open_button.setFocus()
 
         self.refresh()
+        self.resize(400, 550)
 
     def get_name(self):
 

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -295,7 +295,7 @@ class Window(QtWidgets.QDialog):
         self.list.clear()
         items = []
         modified = []
-        for f in os.listdir(self.root):
+        for f in sorted(os.listdir(self.root)):
             if os.path.isdir(os.path.join(self.root, f)):
                 continue
 

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -32,12 +32,12 @@ def determine_application():
 class NameWindow(QtWidgets.QDialog):
     """Name Window"""
 
-    def __init__(self, root, temp_file):
+    def __init__(self, root):
         super(NameWindow, self).__init__()
         self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
 
+        self.result = None
         self.setup(root)
-        self.temp_file = temp_file
 
         self.layout = QtWidgets.QVBoxLayout()
         self.setLayout(self.layout)
@@ -107,15 +107,14 @@ class NameWindow(QtWidgets.QDialog):
         self.refresh()
 
     def on_ok_pressed(self):
-        self.write_data()
+        self.result = self.work_file.replace("\\", "/")
         self.close()
 
     def on_cancel_pressed(self):
         self.close()
 
-    def write_data(self):
-        self.temp_file.write(self.work_file.replace("\\", "/"))
-        self.close()
+    def get_result(self):
+        return self.result
 
     def get_work_file(self):
         data = self.data.copy()
@@ -261,16 +260,12 @@ class Window(QtWidgets.QDialog):
         self.refresh()
 
     def get_name(self):
-        temp = tempfile.TemporaryFile(mode="w+t")
 
-        window = NameWindow(self.root, temp)
+        window = NameWindow(self.root)
         window.setStyleSheet(style.load_stylesheet())
         window.exec_()
 
-        temp.seek(0)
-        name = temp.read()
-        temp.close()
-        return name
+        return window.get_result()
 
     def current_file(self):
         func = {"maya": self.current_file_maya}

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -293,21 +293,23 @@ class Window(QtWidgets.QDialog):
 
     def refresh(self):
         self.list.clear()
-        items = []
+
         modified = []
         for f in sorted(os.listdir(self.root)):
-            if os.path.isdir(os.path.join(self.root, f)):
+            path = os.path.join(self.root, f)
+            if os.path.isdir(path):
                 continue
 
             if self.filter and os.path.splitext(f)[1] not in self.filter:
                 continue
+
             self.list.addItem(f)
-            items.append(self.list.findItems(f, QtCore.Qt.MatchExactly)[0])
-            modified.append(os.path.getmtime(os.path.join(self.root, f)))
+            modified.append(os.path.getmtime(path))
 
         # Select last modified file
-        if items:
-            items[modified.index(max(modified))].setSelected(True)
+        if self.list.count():
+            item = self.list.item(modified.index(max(modified)))
+            item.setSelected(True)
             self.duplicate_button.setEnabled(True)
         else:
             self.duplicate_button.setEnabled(False)

--- a/avalon/tools/workfiles/app.py
+++ b/avalon/tools/workfiles/app.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import tempfile
 import getpass
 import re
 import shutil
@@ -8,7 +7,7 @@ import shutil
 
 from ...vendor.Qt import QtWidgets, QtCore
 from ... import style
-from avalon import io
+from ... import io, api
 
 
 def determine_application():
@@ -180,14 +179,14 @@ class NameWindow(QtWidgets.QDialog):
         # Get work file name
         self.data = {
             "project": io.find_one(
-                {"name": os.environ["AVALON_PROJECT"], "type": "project"}
+                {"name": api.Session["AVALON_PROJECT"], "type": "project"}
             ),
             "asset": io.find_one(
-                {"name": os.environ["AVALON_ASSET"], "type": "asset"}
+                {"name": api.Session["AVALON_ASSET"], "type": "asset"}
             ),
             "task": {
-                "name": os.environ["AVALON_TASK"].lower(),
-                "label": os.environ["AVALON_TASK"]
+                "name": api.Session["AVALON_TASK"].lower(),
+                "label": api.Session["AVALON_TASK"]
             },
             "version": 1,
             "user": getpass.getuser(),


### PR DESCRIPTION
Update Workfiles tool with some new features and fixes

- Sort files by name
- Simplified code
- Avoid temporary file for NamedWindow
- use api.Session, not os.environ
- allow double clicking to open file
- scroll to latest modified file so selected item is visible
- fix auto-increment with gaps and comments
- add a header that shows current context (still ugly, but readable nonetheless)