### PR TITLE
Only hide main avalon container on initial creation 

### DIFF
--- a/avalon/maya/pipeline.py
+++ b/avalon/maya/pipeline.py
@@ -401,6 +401,12 @@ def containerise(name,
     main_container = cmds.ls(AVALON_CONTAINERS, type="objectSet")
     if not main_container:
         main_container = cmds.sets(empty=True, name=AVALON_CONTAINERS)
+
+        # Implement #399: Maya 2019+ hide AVALON_CONTAINERS on creation..
+        if cmds.attributeQuery("hiddenInOutliner",
+                               node=main_container,
+                               exists=True):
+            cmds.setAttr(main_container + ".hiddenInOutliner", True)
     else:
         main_container = main_container[0]
 
@@ -411,10 +417,6 @@ def containerise(name,
                            node=container,
                            exists=True):
         cmds.setAttr(container + ".hiddenInOutliner", True)
-    if cmds.attributeQuery("hiddenInOutliner",
-                           node=main_container,
-                           exists=True):
-        cmds.setAttr(main_container + ".hiddenInOutliner", True)
 
     return container
 


### PR DESCRIPTION
Only hide main avalon container on initial creation. This way it will not interfere with already loaded content in existing scenes.